### PR TITLE
Add missing csv gem required under Ruby 4 -- 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
+gem 'csv'
 gem 'nokogiri'
 gem 'open-uri-cached'
 gem 'activesupport'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
+    csv (3.3.5)
     drb (2.2.3)
     hashdiff (1.2.1)
     i18n (1.14.8)
@@ -74,6 +75,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  csv
   minitest
   nokogiri
   open-uri-cached

--- a/stickshifts.rb
+++ b/stickshifts.rb
@@ -1,5 +1,7 @@
 require 'open-uri/cached';
 require 'fileutils';
+require 'csv';
+
 
 OpenURI::Cache.cache_path = "#{File.dirname(__FILE__)}/tmp/cache"
 FileUtils.mkdir_p OpenURI::Cache.cache_path


### PR DESCRIPTION
CoPilot claims the tests passed in #15 so it must have run under and older Ruby